### PR TITLE
Update ``actions/checkout`` to be ``v3`` to fix issues (from Stack Overflow thread)

### DIFF
--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
     # Checks repo under $GITHUB_WORKSHOP, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
     # Generates the snake  
       - uses: Platane/snk@master


### PR DESCRIPTION
Here is a simple PR which a change to make sure the ``checkout`` action uses ``v3``, which is the newer one which uses Node.js 16 instead of Node.js 12.